### PR TITLE
Feat: 카테고리 선택 컴포넌트 구현

### DIFF
--- a/triangle/src/App.js
+++ b/triangle/src/App.js
@@ -1,12 +1,12 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route} from 'react-router-dom';
 import './App.css';
-import Button from './components/Button';
+import ClubCategoryBox from './components/ClubCategoryBox';
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<Button size="large">Click me</Button>} />
+        <Route path="/" element={<ClubCategoryBox />} />
       </Routes>
     </BrowserRouter>
   );

--- a/triangle/src/components/ClubCategoryBox.css
+++ b/triangle/src/components/ClubCategoryBox.css
@@ -1,0 +1,34 @@
+@font-face {
+    font-family: "Pretendard";
+    src: url("../assets/fonts/Pretendard-Bold.subset.woff2") format("woff2");;
+}
+
+html, body {
+    font-family: "Pretendard", sans-serif;
+}
+
+.ClubCategoryBox_container{
+    width: 100%;
+    height: 45px;
+    background-color: #F9FAFB;
+    border-radius: 15px;
+    display: flex;
+    align-items: center;
+    padding: 0 10px;
+}
+
+.ClubCategoryBox_label{
+    cursor: pointer;
+    font-size: 18px;
+    color: rgba(0,0,0,.5);
+    border-right: 3px solid rgba(0,0,0,.1);
+    padding: 0 12px;
+}
+
+.ClubCategoryBox_label:last-child {
+    border-right: none;
+}
+
+.ClubCategoryBox_label.selected {
+    color: #3B82F6; 
+}

--- a/triangle/src/components/ClubCategoryBox.jsx
+++ b/triangle/src/components/ClubCategoryBox.jsx
@@ -1,0 +1,44 @@
+import React,{useState} from "react";
+import './ClubCategoryBox.css';
+
+const ClubCategoryBox = ({onChange}) =>{
+    const category =["전체","공연분과","체육분과","봉사분과","문화분과","학술분과","종교분과"];
+    const [selected, setSelected] = useState(["전체"]);
+
+    const handleClick=(item)=>{
+        let newSelected;
+
+        if (item === "전체") {
+            newSelected = ["전체"];
+        } else {
+            if (selected.includes(item)) {
+                newSelected = selected.filter(cat => cat !== item);
+                if (newSelected.length === 0) newSelected = ["전체"];
+            } else {
+                newSelected = selected.filter(cat => cat !== "전체");
+                newSelected = [...newSelected, item];
+            }
+        }
+
+        setSelected(newSelected);
+        if (onChange) {
+            onChange(newSelected);
+        }
+    }
+
+    return(
+        <div className="ClubCategoryBox_container">
+            {category.map((item) => (
+                <span
+                    key={item}
+                    className={`ClubCategoryBox_label ${selected.includes(item) ? 'selected' : ''}`}
+                    onClick={() => handleClick(item)}
+                >
+                    {item}
+                </span>
+            ))}
+        </div>
+    )
+}
+
+export default ClubCategoryBox;


### PR DESCRIPTION
closed #20 

작업내용
1. '전체'가 기본 선택된 카테고리이고 '전체'를 제외한 카테고리들은 중복 선택 가능
2. 선택된 카테고리는 파란색으로 표시됨
3. 부모에서 onChange 함수 구현해서 넘겨주면 선택된 카테고리들 전달 가능

<img width="630" alt="화면 캡처 2025-05-22 175539" src="https://github.com/user-attachments/assets/cbbca654-5290-4f7c-bd87-2a10e611aad1" />
