### PR TITLE
Feat: 동아리수 표시, 정렬 컴포넌트 구현

### DIFF
--- a/triangle/package-lock.json
+++ b/triangle/package-lock.json
@@ -8392,7 +8392,6 @@
       "version": "12.12.1",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.12.1.tgz",
       "integrity": "sha512-PFw4/GCREHI2suK/NlPSUxd+x6Rkp80uQsfCRFSOQNrm5pZif7eGtmG1VaD/UF1fW9tRBy5AaS77StatB3OJDg==",
-      "license": "MIT",
       "dependencies": {
         "motion-dom": "^12.12.1",
         "motion-utils": "^12.12.1",
@@ -11250,7 +11249,6 @@
       "version": "0.511.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.511.0.tgz",
       "integrity": "sha512-VK5a2ydJ7xm8GvBeKLS9mu1pVK6ucef9780JVUjw6bAjJL/QXnd4Y0p7SPeOUMC27YhzNCZvm5d/QX0Tp3rc0w==",
-      "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }

--- a/triangle/src/components/ClubSort/ClubCountAndAlignBox.css
+++ b/triangle/src/components/ClubSort/ClubCountAndAlignBox.css
@@ -1,13 +1,3 @@
-@font-face {
-    font-family: "Pretendard";
-    src: url("../../assets/fonts/Pretendard-Bold.subset.woff2") format("woff2");;
-}
-
-html, body {
-    font-family: "Pretendard", sans-serif;
-}
-
-
 .ClubCountAndAlignBox_container{
     width: 100%;
     height: 30px;
@@ -15,6 +5,7 @@ html, body {
 }
 
 .ClubCountAndAlignBox_label{
+    font-family: "Pretendard0Bold", sans-serif;
     font-size: 17px;
     color : rgba(0,0,0,.6);
     margin-right: auto;

--- a/triangle/src/components/ClubSort/ClubCountAndAlignBox.css
+++ b/triangle/src/components/ClubSort/ClubCountAndAlignBox.css
@@ -5,7 +5,7 @@
 }
 
 .ClubCountAndAlignBox_label{
-    font-family: "Pretendard0Bold", sans-serif;
+    font-family: "Pretendard-Bold", sans-serif;
     font-size: 17px;
     color : rgba(0,0,0,.6);
     margin-right: auto;

--- a/triangle/src/components/ClubSort/ClubCountAndAlignBox.css
+++ b/triangle/src/components/ClubSort/ClubCountAndAlignBox.css
@@ -1,0 +1,24 @@
+@font-face {
+    font-family: "Pretendard";
+    src: url("../../assets/fonts/Pretendard-Bold.subset.woff2") format("woff2");;
+}
+
+html, body {
+    font-family: "Pretendard", sans-serif;
+}
+
+
+.ClubCountAndAlignBox_container{
+    width: 100%;
+    height: 30px;
+    display: flex;
+}
+
+.ClubCountAndAlignBox_label{
+    font-size: 17px;
+    color : rgba(0,0,0,.6);
+    margin-right: auto;
+}
+
+
+

--- a/triangle/src/components/ClubSort/ClubCountAndAlignBox.jsx
+++ b/triangle/src/components/ClubSort/ClubCountAndAlignBox.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import './ClubCountAndAlignBox.css';
+import SortDropdown from "../ClubSort/SortDropDown"
+
+const ClubCountAndAlignBox = ({count})=>{
+
+    const handleSort = key => {
+    console.log(key);
+  };
+
+    return(
+        <div className="ClubCountAndAlignBox_container">
+            <div className="ClubCountAndAlignBox_label">총 {count}개의 동아리</div>
+            <SortDropdown onSelect={handleSort} />
+        </div>
+    );
+}
+
+export default ClubCountAndAlignBox;

--- a/triangle/src/components/ClubSort/SortDropDown.css
+++ b/triangle/src/components/ClubSort/SortDropDown.css
@@ -1,0 +1,56 @@
+@font-face {
+    font-family: "Pretendard";
+    src: url("../../assets/fonts/Pretendard-Bold.subset.woff2") format("woff2");;
+}
+
+html, body {
+    font-family: "Pretendard", sans-serif;
+}
+
+
+.sort-dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.sort-button {
+  margin-left: auto;
+  font-size: 17px;
+  color: rgba(0, 0, 0, .6);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.sort-button.active {
+  color: #3B82F6; 
+}
+
+.sort-menu {
+  position: absolute;
+  right: 0;
+  margin-top: 6px;
+  width: 170px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  z-index: 100;
+}
+
+.sort-item {
+  display: block;
+  width: 90%;
+  margin: 7px;
+  padding: 10px;
+  text-align: center;
+  background: none;
+  border: none;
+  font-size: 16px;
+  color: rgba(0, 0, 0, .6);
+  cursor: pointer;
+}
+
+.sort-item.selected {
+  border-radius: 15px;
+  background-color: #f0f0f0;
+  color: black;
+}

--- a/triangle/src/components/ClubSort/SortDropDown.css
+++ b/triangle/src/components/ClubSort/SortDropDown.css
@@ -1,19 +1,10 @@
-@font-face {
-    font-family: "Pretendard";
-    src: url("../../assets/fonts/Pretendard-Bold.subset.woff2") format("woff2");;
-}
-
-html, body {
-    font-family: "Pretendard", sans-serif;
-}
-
-
 .sort-dropdown {
   position: relative;
   display: inline-block;
 }
 
 .sort-button {
+  font-family: "Pretendard0Bold", sans-serif;
   margin-left: auto;
   font-size: 17px;
   color: rgba(0, 0, 0, .6);

--- a/triangle/src/components/ClubSort/SortDropDown.css
+++ b/triangle/src/components/ClubSort/SortDropDown.css
@@ -4,7 +4,7 @@
 }
 
 .sort-button {
-  font-family: "Pretendard0Bold", sans-serif;
+  font-family: "Pretendard-Bold", sans-serif;
   margin-left: auto;
   font-size: 17px;
   color: rgba(0, 0, 0, .6);

--- a/triangle/src/components/ClubSort/SortDropDown.jsx
+++ b/triangle/src/components/ClubSort/SortDropDown.jsx
@@ -1,0 +1,48 @@
+import React, { useState, useRef, useEffect } from 'react';
+import './SortDropDown.css';
+
+export default function SortDropdown({ onSelect }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selected, setSelected] = useState('name');
+  const menuRef = useRef(null);
+
+  useEffect(() => {
+    function handleClickOutside(e) {
+      if (menuRef.current && !menuRef.current.contains(e.target)) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleSelect = (type) => {
+    setSelected(type);
+    onSelect(type);
+  };
+
+  return (
+    <div className="sort-dropdown" ref={menuRef}>
+      <div className={`sort-button ${isOpen ? 'active' : ''}`} onClick={() => setIsOpen(open => !open)}>
+        정렬
+      </div>
+
+      {isOpen && (
+        <div className="sort-menu">
+          <button
+            className={`sort-item ${selected === 'name' ? 'selected' : ''}`}
+            onClick={() => handleSelect('name')}
+          >
+            동아리명으로 정렬
+          </button>
+          <button
+            className={`sort-item ${selected === 'category' ? 'selected' : ''}`}
+            onClick={() => handleSelect('category')}
+          >
+            카테고리로 정렬
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/triangle/src/pages/TestPage.jsx
+++ b/triangle/src/pages/TestPage.jsx
@@ -3,7 +3,7 @@ import React from "react";
 function TestPage(){
     return(
         <div>
-            testPage입니다.
+           
         </div>
     )
 }


### PR DESCRIPTION
## 📌 PR 제목
[Feature] 동아리 수 표시, 동아리 정렬 선택 컴포넌트 구현

## ✅ 작업 내용  
- 동아리 수 표시
- 동아리 정렬 방식을 동아리명 또는 카테고리 순으로 선택 가능한 컴포넌트 구현

### ✨ 상세 내용  
- 동아리 검색 또는 카테고리 선택 시 결과로 나타나는 동아리 수 표시
-  정렬 버튼 클릭시 선택 가능한 메뉴가 드롭다운 박스로 버튼 아래에 나타남

## 📸 화면 캡처
<img width="373" alt="화면 캡처 2025-05-23 193523" src="https://github.com/user-attachments/assets/0a163c3c-3ba3-4aa3-8012-2dd3fc1831a5" />


## 📚 참고 사항 (선택)  

## 🔗 관련 이슈  
closed #31 
