### PR TITLE
Feat: 동아리 선택 시 동아리 상세 페이지로 이동하는 기능 구현

### DIFF
--- a/triangle/src/components/ClubNameBox.css
+++ b/triangle/src/components/ClubNameBox.css
@@ -33,11 +33,13 @@ html, body {
     margin-left: 25px;
     border-right: 2.5px solid rgba(0,0,0,.1);
     padding-right: 7px;
+    cursor: pointer;
 }
 
 .ClubNameBox_label{
     color:#686868;
     padding-left: 7px;
+    cursor: pointer;
 }
 
 .ClubNameBox_icon_wrapper{

--- a/triangle/src/components/TopNavbar.css
+++ b/triangle/src/components/TopNavbar.css
@@ -8,7 +8,7 @@
     
 }
 
-.TopNavBar_Logo_container{
+.TopNavBar_Logo_Container{
     margin: 0 auto;
     position: relative;
     width: 1120px;
@@ -16,7 +16,6 @@
     flex-direction: column;
     pointer-events: none;
 }
-
 
 .TopNavBar_Logo{
     max-height: 80px; 
@@ -27,5 +26,5 @@
 }
 
 .TopNavBar_Logo_container img {
-  pointer-events: auto;
+    pointer-events: auto;
 }

--- a/triangle/src/components/TopNavbar.jsx
+++ b/triangle/src/components/TopNavbar.jsx
@@ -1,14 +1,12 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import '../components/TopNavbar.css';
+import './TopNavbar.css';
 import logo from '../assets/images/triangle_logo.png';
 
-const Top_Navbar = () =>{
-
-
+const TopNavbar = () =>{
     return(
         <div className="TopNavBar_Container">
-            <div className="TopNavBar_Logo_container">
+            <div className="TopNavBar_Logo_Container">
                 <Link to="/main">
                     <img
                         src={logo}
@@ -21,4 +19,4 @@ const Top_Navbar = () =>{
     );
 }
 
-export default Top_Navbar;
+export default TopNavbar;

--- a/triangle/src/pages/ClubInfo/ClubInfo.css
+++ b/triangle/src/pages/ClubInfo/ClubInfo.css
@@ -1,6 +1,7 @@
 .ClubInfo_clubInfoContainer {
   width: 60%;
   margin: auto;
+  padding-top: 80px;
 }
 
 .ClubInfo_Section {

--- a/triangle/src/pages/ClubInfo/ClubInfo.jsx
+++ b/triangle/src/pages/ClubInfo/ClubInfo.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import '../../index.css';
 import { useParams } from 'react-router-dom';
-import Button from '../../components/Button';
+import Button from '../../components/Button/Button';
 import ClubinfoBox from '../../components/ClubinfoBox';
 import ClubDetailTitle from '../../components/clubDetailTitle/clubDetailTitle';
 import clubData from '../../constants/sejong_all_clubs.json';

--- a/triangle/src/pages/MainPage/MainPage.jsx
+++ b/triangle/src/pages/MainPage/MainPage.jsx
@@ -1,4 +1,5 @@
 import React,{useState} from "react";
+import { useNavigate } from "react-router-dom";
 import './MainPage.css';
 import SearchBox from "../../components/SearchBox";
 import ClubCountAndAlignBox from "../../components/ClubSort/ClubCountAndAlignBox";
@@ -10,6 +11,7 @@ const MainPage = ()=>{
     const [selectedCategories, setSelectedCategories] = useState(["전체"]);
     const [sortType, setSortType] = useState('name');
     const [searchTerm, setSearchTerm] = useState('');
+    const navigate = useNavigate();
 
     const handleCategoryChange = (categories) => {
         setSelectedCategories(categories);
@@ -46,12 +48,16 @@ const MainPage = ()=>{
             <ClubCategoryBox onChange={handleCategoryChange}/>
             <div className="MainPage_ClubList">
                 {sortedClubs.map((club, index) => (
-                <ClubNameBox
-                    key={index}
-                    name={club.name}
-                    type={club.category}
-                    detail={club.area}
-                />
+                <div
+                    key={club.id}
+                    onClick={() => navigate(`/club/${club.id}`)}
+                >
+                     <ClubNameBox
+                        name={club.name}
+                        type={club.category}
+                        detail={club.area}
+                    />
+                </div>
             ))}
             </div>
             

--- a/triangle/src/router.jsx
+++ b/triangle/src/router.jsx
@@ -7,6 +7,7 @@ import { DescriptionChatBotPage } from "./pages/DescriptionChatBotPage/Descripti
 import { DescriptionLayout } from "./layouts/DescriptionLayout/DescriptionLayout";
 import LandingPage from "./pages/LandingPage/LandingPage";
 import MainPage from "./pages/MainPage/MainPage";
+import { ClubInfo } from "./pages/ClubInfo/ClubInfo";
 
 const router = createBrowserRouter([
     {
@@ -16,6 +17,7 @@ const router = createBrowserRouter([
             {index: true, element: <LandingPage/>},
             {path: '*', element: <NotFoundPage/>},
             {path: 'main', element: <MainPage/>},
+            {path: 'club/:id', element: <ClubInfo/> },
             {path: 'detail', element: <TestPage/>},
          
         ]


### PR DESCRIPTION
## 📌 PR 제목
[Feature] 동아리 선택 시 동아리 상세 페이지로 이동하는 기능 구현

---

## ✅ 작업 내용  
- 동아리 선택 시 동아리 상세 페이지로 이동

### ✨ 상세 내용  
- 라우터에 동아리 상세 페이지 추가
- navigate 사용하여 해당 동아리 id에 해당하는 동아리의 정보 보여주는 페이지로 이동
- 헤더에 의해 상세 페이지 윗 부분 잘리는 문제 해결 위해 padding 값 약간 수
---

## 📸 화면 캡처 (선택)
<img width="1280" alt="화면 캡처 2025-05-24 234309" src="https://github.com/user-attachments/assets/bff9035c-a98e-473b-8514-009e62baed3d" />


---

## 📚 참고 사항 (선택)  

---

## 🔗 관련 이슈  
closed #48 
