### PR TITLE
[Feature] 상세페이지 동아리설명 style 양식 추가

### DIFF
--- a/triangle/src/pages/ClubInfo/ClubInfo.css
+++ b/triangle/src/pages/ClubInfo/ClubInfo.css
@@ -32,6 +32,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  font-size: 1.2em;
   font-weight: bold;
   color: rgb(44, 107, 255);
   border-bottom: 3px solid rgb(44, 107, 255);
@@ -39,6 +40,7 @@
 }
 
 .ClubInfo_TextStart {
+  font-size: 1.3em;
   font-weight: bold;
   margin-bottom: 15px;
 }
@@ -54,9 +56,24 @@
   width: 100%;
 }
 
-.ClubInfo_TextDetail {
-  margin-left: 1em;
-  font-weight: bold;
-  font-size: 0.8em;
+.ClubInfo_DescriptionList {
+  margin-left: 0.9em;
   color: gray;
+  font-weight: bold;
+  list-style-type: none;
+}
+
+.ClubInfo_DescriptionTitle {
+  font-size: 1.2em;
+  color: black;
+  margin-top: 24px;
+  margin-bottom: 8px;
+}
+
+.ClubInfo_DescriptionParagraph {
+  margin-left: 1.2em;
+}
+
+.ClubInfo_Bottom {
+  margin-bottom: 80px;
 }

--- a/triangle/src/pages/ClubInfo/ClubInfo.jsx
+++ b/triangle/src/pages/ClubInfo/ClubInfo.jsx
@@ -43,14 +43,32 @@ const ClubInfo = () => {
         <div className="ClubInfo_section3">
           <div className="ClubInfo_clubIntro">동아리 소개</div>
           <div className="ClubInfo_TextSection">
-            <div className="ClubInfo_TextStart">동아리를 소개합니다.</div>
+            <div className="ClubInfo_TextStart">동아리 소개 - 이미지</div>
             <div className="ClubInfo_clubImage">
               <img
                 src={clubImage}
                 alt="동아리사진"
             />
             </div>
-            <div className="ClubInfo_TextDetail">{club.detail.description}</div>
+            <ul className="ClubInfo_DescriptionList">
+              {club.detail.description.map((paragraph, index) => {
+              const isTitle = index % 2 === 0;
+              const content = paragraph.split('\n');
+
+              return (
+                <li key={index} className={isTitle ? "ClubInfo_DescriptionTitle" : "ClubInfo_DescriptionParagraph"}>
+                  {isTitle ? (
+                  <span>{paragraph}</span>
+                  ) : (
+                  content.map((line, i) => (
+                  <span key={i} style={{ display: 'block' }}>{line}</span>
+                  ))
+                  )}
+                </li>
+              );
+            })}
+            </ul>
+            <div className="ClubInfo_Bottom"></div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 📌 PR 제목
<!-- 예시: [Feature] 회원가입 폼 구현 -->
[Feature] 상세페이지 동아리설명 style 양식 추가
---

## ✅ 작업 내용  
- [x] 배열로 이루어진 동아리 설명 불러오기
- [x] 동아리 설명의 제목과 내용 부분을 분리하여 서로 다른 style 적용시키기

### ✨ 상세 내용  

1. 동아리에 대한 설명을 json 파일에서 배열의 형태로 저장해두었습니다.
2. 해당 배열은 제목-내용의 짝의 형태를 이루고 있기 때문에 홀수번(1,3..)과 짝수번(0,2..)을 분리하여 style을 적용시켰습니다.
3. 동아리 설명이 끝나는 지점이 상세페이지의 최하단 바닥부분과 바로 붙어있는 점이 어색해 인위적으로 바닥 공간을 확보하는 div 태그를 추가해 바닥 영역에 여유를 줬습니다.
---

## 📸 화면 캡처 (선택)  
![1a](https://github.com/user-attachments/assets/80c4f06f-7314-40e5-a5af-f34b025559cd)
위와 같은 형태의 경우
[0] : 늘혬코러스에 관하여
[1] : 늘혬코러스는~~
[2] : 모집에 관하여
[3] : 모집기간은~~
[4] : 더 알아보기
[5] : 늘혬가~~
와 같은 형태의 배열이 홀수번과 짝수번에 서로 다른 스타일을 적용받은 결과물입니다.
![2a](https://github.com/user-attachments/assets/c34c1682-9bf2-40bd-adf2-b8a27d822b2b)
![3a](https://github.com/user-attachments/assets/3b5c7e21-8224-4b5a-90ae-82a4c760ee81)
소모임, 종교 동아리, 일부 동아리의 경우 자료가 부족하여 상대적으로 설명이 빈약합니다.

---

## 📚 참고 사항 (선택)  
---
앞서 설명한 바와 같이 동아리 상세 설명은 제목-내용의 짝으로 이루어져 있기 때문에 이를 고려하지 않고 json 파일을 수정 시 상세페이지 디자인이 의도한 바와는 다르게 일그러질 수 있음을 미리 알립니다.
글씨 굵기를 bold가 아닌 더 얇은 폰트 사용 시 "혬"과 같은 일부 한글 글자가 깨져 보여 폰트 굵기 수정을 추천하지 않습니다.

## 🔗 관련 이슈  
Closes #75